### PR TITLE
Fix #54 + Release v0.2.1: FLAG_REQUIRED enforced on options

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -70,7 +70,7 @@ jobs:
         mkdir -p artifacts/include
 
         cp .build/libargus.a artifacts/lib/
-        cp .build/libargus.so.0.1.0 artifacts/lib/
+        find .build -maxdepth 1 -type f -name 'libargus.so.*' -exec cp -t artifacts/lib/ {} +
 
         cp -r includes/argus artifacts/include/
         cp includes/argus.h artifacts/include/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [0.2.1] - 2026-05-13
+
+### Fixed
+- `FLAG_REQUIRED` is now enforced on options (not just positional arguments), at both root and subcommand levels (#54).
+- Bumped `ARGUS_VERSION` and packaging metadata to match the actual released version (previously stuck at `0.1.0`).
+
+
 ## [0.2.0] - 2025-10-01
 
 ### Added
@@ -137,4 +144,6 @@ This marks the first stable release of Argus, a modern C library for command-lin
 The library is production-ready and includes comprehensive documentation, examples, and automated testing across multiple platforms.
 
 [0.1.0]: https://github.com/lucocozz/argus/releases/tag/v0.1.0
-[Unreleased]: https://github.com/lucocozz/argus/compare/v0.1.0...HEAD
+[0.2.0]: https://github.com/lucocozz/argus/releases/tag/v0.2.0
+[0.2.1]: https://github.com/lucocozz/argus/releases/tag/v0.2.1
+[Unreleased]: https://github.com/lucocozz/argus/compare/v0.2.1...HEAD

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The result is the same functionality with significantly less code and automatic 
 ```bash
 # Package managers
 vcpkg install argus
-conan install argus/0.1.0
+conan install argus/0.2.1
 
 # From source
 git clone https://github.com/lucocozz/argus.git

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -31,9 +31,9 @@ vcpkg install argus
 
 ```bash
 # With Regex support (requires PCRE2)
-conan install argus/0.1.0 -o argus:regex=True
+conan install argus/0.2.1 -o argus:regex=True
 # Without Regex support (default)
-conan install argus/0.1.0
+conan install argus/0.2.1
 ```
 
 </TabItem> -->
@@ -97,9 +97,9 @@ vcpkg install argus
 
 ```bash
 # With Regex support (requires PCRE2)
-conan install argus/0.1.0 -o argus:regex=True
+conan install argus/0.2.1 -o argus:regex=True
 # Without Regex support (default)
-conan install argus/0.1.0
+conan install argus/0.2.1
 ```
 
 </TabItem> -->
@@ -170,9 +170,9 @@ vcpkg install argus
 
 ```bash
 # With Regex support (requires PCRE2)
-conan install argus/0.1.0 -o argus:regex=True
+conan install argus/0.2.1 -o argus:regex=True
 # Without Regex support (default)
-conan install argus/0.1.0
+conan install argus/0.2.1
 ```
 
 </TabItem> -->

--- a/includes/argus.h
+++ b/includes/argus.h
@@ -18,6 +18,6 @@
 /**
  * ARGUS_VERSION - Library version
  */
-#define ARGUS_VERSION "0.1.0"
+#define ARGUS_VERSION "0.2.1"
 
 #endif /* ARGUS_H */

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'argus', 'c',
-    version: '0.1.0',
+    version: '0.2.1',
     license: 'MIT',
     default_options: [
         'warning_level=3',

--- a/source/core/parsing/post_parse_validation.c
+++ b/source/core/parsing/post_parse_validation.c
@@ -83,6 +83,12 @@ static int validate_options_set(argus_t *argus, argus_option_t *options)
             return (ARGUS_ERROR_MISSING_REQUIRED);
         }
 
+        if (option->type == TYPE_OPTION && (option->flags & FLAG_REQUIRED) && !option->is_set) {
+            ARGUS_PARSING_ERROR(argus, ARGUS_ERROR_MISSING_REQUIRED,
+                                "Required option is missing: '--%s'", option->name);
+            return (ARGUS_ERROR_MISSING_REQUIRED);
+        }
+
         if (option->is_set) {
             int status;
 

--- a/tests/integration/test_post_validation.c
+++ b/tests/integration/test_post_validation.c
@@ -27,6 +27,14 @@ ARGUS_OPTIONS(
     POSITIONAL_STRING("input", HELP("Input file")),
 )
 
+// Regression test for #54: FLAG_REQUIRED on a non-positional option.
+ARGUS_OPTIONS(
+    required_option_options,
+    HELP_OPTION(),
+    OPTION_STRING('a', "algo", HELP("Algorithm"), FLAGS(FLAG_REQUIRED)),
+    OPTION_STRING('o', "output", HELP("Output path")),
+)
+
 // Test post_parse_validation with required positionals
 Test(post_validation, required_positional)
 {
@@ -123,6 +131,42 @@ Test(post_validation, exclusive_groups)
     cr_assert_neq(status, ARGUS_SUCCESS, "Validation should fail due to exclusive group violation");
     
     // Clean up
+    argus_free(&argus);
+}
+
+// Regression for #54: a missing FLAG_REQUIRED option must fail validation.
+Test(post_validation, required_option_missing)
+{
+    char *argv[] = {"test_program", "-o", "out.bin"};
+    int argc = sizeof(argv) / sizeof(char *);
+
+    argus_t argus = argus_init(required_option_options, "test_program", "1.0.0");
+
+    int status = parse_args(&argus, required_option_options, argc - 1, &argv[1]);
+    cr_assert_eq(status, ARGUS_SUCCESS, "Initial parsing should succeed");
+
+    status = post_parse_validation(&argus);
+    cr_assert_eq(status, ARGUS_ERROR_MISSING_REQUIRED,
+                 "Validation should fail when a FLAG_REQUIRED option is missing");
+
+    argus_free(&argus);
+}
+
+// Regression for #54: a present FLAG_REQUIRED option must pass validation.
+Test(post_validation, required_option_present)
+{
+    char *argv[] = {"test_program", "-a", "RSA", "-o", "out.bin"};
+    int argc = sizeof(argv) / sizeof(char *);
+
+    argus_t argus = argus_init(required_option_options, "test_program", "1.0.0");
+
+    int status = parse_args(&argus, required_option_options, argc - 1, &argv[1]);
+    cr_assert_eq(status, ARGUS_SUCCESS, "Initial parsing should succeed");
+
+    status = post_parse_validation(&argus);
+    cr_assert_eq(status, ARGUS_SUCCESS,
+                 "Validation should succeed when FLAG_REQUIRED option is provided");
+
     argus_free(&argus);
 }
 

--- a/tests/integration/test_subcommand_edge_case.c
+++ b/tests/integration/test_subcommand_edge_case.c
@@ -238,6 +238,49 @@ Test(subcommand_edge, subcommand_negative_number, .init = setup_subcommand)
     argus_free(&argus);
 }
 
+// Regression for #54: FLAG_REQUIRED on a subcommand option must fail validation
+// when the option is missing.
+ARGUS_OPTIONS(
+    keygen_options,
+    HELP_OPTION(),
+    OPTION_STRING('a', "algo", HELP("Algorithm"), FLAGS(FLAG_REQUIRED)),
+    OPTION_STRING('o', "output", HELP("Output path")),
+)
+
+ARGUS_OPTIONS(
+    keygen_cmd_options,
+    HELP_OPTION(),
+    SUBCOMMAND("keygen", keygen_options, HELP("Generate keys")),
+)
+
+Test(subcommand_edge, subcommand_required_option_missing, .init = setup_subcommand)
+{
+    char *argv[] = {"test", "keygen", "-o", "out.bin"};
+    int argc = sizeof(argv) / sizeof(char *);
+
+    argus_t argus = argus_init(keygen_cmd_options, "test", "1.0.0");
+    int status = argus_parse(&argus, argc, argv);
+
+    cr_assert_eq(status, ARGUS_ERROR_MISSING_REQUIRED,
+                 "Subcommand FLAG_REQUIRED option missing should fail validation");
+
+    argus_free(&argus);
+}
+
+Test(subcommand_edge, subcommand_required_option_present, .init = setup_subcommand)
+{
+    char *argv[] = {"test", "keygen", "-a", "RSA", "-o", "out.bin"};
+    int argc = sizeof(argv) / sizeof(char *);
+
+    argus_t argus = argus_init(keygen_cmd_options, "test", "1.0.0");
+    int status = argus_parse(&argus, argc, argv);
+
+    cr_assert_eq(status, ARGUS_SUCCESS,
+                 "Subcommand FLAG_REQUIRED option present should succeed");
+
+    argus_free(&argus);
+}
+
 // Test Validator invalid value in subcommands
 Test(subcommand_edge, subcommand_invalid_value, .init = setup_subcommand)
 {


### PR DESCRIPTION
## Summary

- **Fixes #54** — `FLAG_REQUIRED` was only enforced on `TYPE_POSITIONAL`. A required `OPTION_STRING` / `OPTION_INT` / etc. at either root or subcommand level was silently accepted when missing, causing `argus_parse` to return `ARGUS_SUCCESS` and the action handler to run with the option unset (often segfaulting downstream when the caller dereferenced the unset value).
- **Bumps version to `v0.2.1`** — `ARGUS_VERSION` and `meson.build` were stuck at `0.1.0` even though tag `v0.2.0` shipped on 2025-10-01. The library now reports its actual version.
- **#53 already fixed** by `c15296a "Fixing unexecuted validators in subcommand"` (shipped in v0.2.0), confirmed via reproduction on current `develop`.

## Changes

- `source/core/parsing/post_parse_validation.c` — add parallel `FLAG_REQUIRED` check for `TYPE_OPTION` next to the existing `TYPE_POSITIONAL` one.
- `tests/integration/test_post_validation.c` — `required_option_missing` / `required_option_present` (root level).
- `tests/integration/test_subcommand_edge_case.c` — `subcommand_required_option_missing` / `subcommand_required_option_present`.
- `meson.build`, `includes/argus.h` — `0.1.0` → `0.2.1`.
- `CHANGELOG.md` — new `[0.2.1]` section.
- `README.md`, `docs/.../installation.md` — Conan install example `argus/0.1.0` → `argus/0.2.1`.

## Test plan

- [ ] CI passes (`tests`, `build-ubuntu`, `build-macos`, `build-windows`, `lint`)
- [ ] `meson test -C build --suite integration` passes the 4 new tests
- [ ] Repro: `./binary keygen -o RSA.key` (without `--algo` flagged `FLAG_REQUIRED`) → exits with `ARGUS_ERROR_MISSING_REQUIRED` (14) instead of segfault
- [ ] `--version` output reports `0.2.1`

## Out of scope

- `packaging/{vcpkg,conan}` metadata left at `0.1.0` per your instruction — you'll refactor packaging separately.
- `tests/unit/test_robustness.c:30 robustness.missing_required` already asserted exactly this behavior — worth investigating why CI didn't catch the bug (test never ran, or failing silently).